### PR TITLE
Parameterize mvn copy command so it can be overridden

### DIFF
--- a/docker-files/Dockerfile
+++ b/docker-files/Dockerfile
@@ -18,9 +18,11 @@
 # FROM java:8
 FROM maven:3.3-jdk-8-alpine
 
+ARG MVN_COMMAND="mvn dependency:copy -q"
+
 COPY docker-files/pom.xml .
 
-RUN mvn dependency:copy -q
+RUN $MVN_COMMAND
 
 FROM alpine:3.6
 MAINTAINER Jim White <james_white2@dell.com>

--- a/docker-files/Dockerfile.aarch64
+++ b/docker-files/Dockerfile.aarch64
@@ -18,11 +18,13 @@
 FROM arm64v8/alpine:3.6
 MAINTAINER Federico Claramonte <fede.claramonte@caviumnetworks.com>
 
+ARG MVN_COMMAND="mvn dependency:copy -q"
+
 RUN apk --update add openjdk8-jre maven
 
 COPY docker-files/pom.xml .
 
-RUN mvn dependency:copy -q
+RUN $MVN_COMMAND
 
 FROM arm64v8/alpine:3.6
 

--- a/docker-files/pom.xml
+++ b/docker-files/pom.xml
@@ -18,6 +18,7 @@
     <properties>
         <nexusproxy>https://nexus.edgexfoundry.org</nexusproxy>
         <repobasepath>content/repositories</repobasepath>
+        <stagingpath>staging</stagingpath>
     </properties>
     
     <build>
@@ -49,7 +50,7 @@
 		<repository>
                        <id>staging</id>
                        <name>EdgeX Staging Repository</name>
-                       <url>${nexusproxy}/${repobasepath}/staging</url>
+                       <url>${nexusproxy}/${repobasepath}/${stagingpath}</url>
                </repository>
                <repository>
                        <id>snapshots</id>


### PR DESCRIPTION
This will make it easy to set a -D property to point
it to a particular staging repo for staging builds.

Signed-off-by: Jeremy Phelps <jphelps@linuxfoundation.org>