### PR TITLE
Rev rules engine to 1.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.edgexfoundry</groupId>
 	<artifactId>support-rulesengine</artifactId>
-	<version>0.7.0-SNAPSHOT</version>
+	<version>1.0.0-SNAPSHOT</version>
 	<name>EdgeX Foundry Rules Engine Micro Service</name>
 	<description>EdgeX Foundry Rules Engine Micro Service</description>
 


### PR DESCRIPTION
Incrementing version to 1.0.0 for inclusion in Nexus. Needed for docker-based blackbox tests.

Signed-off-by: Trevor Conn <trevor_conn@dell.com>