### PR TITLE
Update Configuration for self-seed.

### DIFF
--- a/docker-files/application.properties
+++ b/docker-files/application.properties
@@ -23,18 +23,18 @@
 heart.beat.time=300000
 #messages
 heart.beat.msg=Support Rules Engine data heart beat
-app.open.msg=This is the Support Rules Engine Micro Service.
+app.open.msg=This is the Support Rules Engine Microservice.
 # set port (override Spring boot default port 8080 )
 server.port=48075
-#-----------------Export Service Config----------------------------------------
-#Turn on/off registration of rules engine as export distro client.  
+#-----------------App Service Configurable Rules Config----------------------------------------
+#Turn on/off registration of rules engine as app-service-configurable client.
 #Set to false to receive messages directly from core data
 export.client=false
 expect.serializedjava=false
 #export.client.registration.url=http://localhost:48071/api/v1
 export.client.registration.url=http://edgex-export-client:48071/api/v1
 export.client.registration.name=EdgeXRulesEngine
-#use port 5566 when connected to export distro
+#use port 5566 when connected to app-service-configurable
 #use port 5563 when connected to core data directly
 export.zeromq.port=5566
 #export.zeromq.port=5563
@@ -90,8 +90,3 @@ meta.db.provisionwatcher.url=http://edgex-core-metadata:48081/api/v1/provisionwa
 logging.remote.enable=true
 #logging.remote.url=http://localhost:48061/api/v1/logs
 logging.remote.url=http://edgex-support-logging:48061/api/v1/logs
-
-#-----------------Consul Config------------------------------------------
-#The health checking path for Service Registry
-spring.cloud.consul.discovery.healthCheckPath=/api/v1/ping
-

--- a/docker-files/bootstrap.properties
+++ b/docker-files/bootstrap.properties
@@ -18,5 +18,5 @@ spring.application.name=edgex-support-rulesengine
 spring.cloud.consul.host=edgex-core-consul
 spring.cloud.consul.port=8500
 spring.cloud.consul.config.profileSeparator=;
-spring.cloud.consul.enabled=true
+spring.cloud.consul.enabled=false
 spring.profiles.active=docker

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -22,23 +22,23 @@
 heart.beat.time=300000
 #messages
 heart.beat.msg=Support Rules Engine data heart beat
-app.open.msg=This is the Support Rules Engine Micro Service.
+app.open.msg=This is the Support Rules Engine Microservice.
 # set port (override Spring boot default port 8080 )
 server.port=48075
-#-----------------Export Service Config----------------------------------------
-#Turn on/off registration of rules engine as export distro client.
+#-----------------App Service Configurable Rules Config----------------------------------------
+#Turn on/off registration of rules engine as app-service-configurable client.
 #Set to false to receive messages directly from core data
 export.client=false
 expect.serializedjava=false
 export.client.registration.url=http://localhost:48071/api/v1
 #export.client.registration.url=http://edgex-export-client:48071/api/v1
 export.client.registration.name=EdgeXRulesEngine
-#use port 5566 when connected to export distro
+#use port 5566 when connected to app-service-configurable
 #use port 5563 when connected to core data directly
 export.zeromq.port=5566
 #export.zeromq.port=5563
 export.zeromq.host=tcp://localhost
-#export.zeromq.host=tcp:/edgex-app-service-configurable-rules
+#export.zeromq.host=tcp://edgex-app-service-configurable-rules
 #how long to wait to retry registration
 export.client.registration.retry.time=10000
 #how many times to try registration before exiting
@@ -89,7 +89,3 @@ meta.db.provisionwatcher.url=http://localhost:48081/api/v1/provisionwatcher
 #logging.remote.enable=true
 logging.remote.url=http://localhost:48061/api/v1/logs
 #logging.remote.url=http://edgex-support-logging:48061/api/v1/logs
-
-#-----------------Consul Config------------------------------------------
-#The health checking path for Service Registry
-spring.cloud.consul.discovery.healthCheckPath=/api/v1/ping


### PR DESCRIPTION
Fix #68 
- To enable services to self-seed their configurations, the properties of the `RulesEngine` were updated whereby `RulesEngine` retrieves its configuration _locally_ instead of going to `Consul`. 
- Regarding the `application.properties` (both for `local` and `Docker`), I ensured that their contents reflect the new app services properties that were added to `config-seed` but not (at one point in the past) to the properties file in `RulesEngine`. I did update the comments in aforesaid `application.properties` files as they were out-of-date.
- Tested the update to validate that `RulesEngine` does not go to `Consul` and that it retrieves its configuration _locally_.
- Sample output from containerized launch of `RulesEngine`:
```
[2020-04-03 15:31:39.188] boot - 7  INFO [main] --- AutowiredAnnotationBeanPostProcessor: JSR-330 'javax.inject.Inject' annotation found and supported for autowiring,
[2020-04-03 15:31:39.261] boot - 7  INFO [main] --- PostProcessorRegistrationDelegate$BeanPostProcessorChecker: Bean 'configurationPropertiesRebinderAutoConfiguration' of type [class org.springframework.cloud.autoconfigure.ConfigurationPropertiesRebinderAutoConfiguration$$EnhancerBySpringCGLIB$$b0c4e4ed] is not eligible for getting processed by all BeanPostProcessors (for example: not eligible for auto-proxying),
  ___    _         __  __        ___      _          ___           _          ,
 | __|__| |__ _ ___\ \/ /  ___  | _ \_  _| |___ ___ | __|_ _  __ _(_)_ _  ___ ,
 | _|/ _` / _` / -_)>  <  |___| |   / || | / -_|_-< | _|| ' \/ _` | | ' \/ -_),
 |___\__,_\__, \___/_/\_\       |_|_\\_,_|_\___/__/ |___|_||_\__, |_|_||_\___|,
          |___/                                              |___/            ,
/*******************************************************************************,
 * Copyright 2016-2017, Dell, Inc.  All Rights Reserved.,
 ******************************************************************************/,
 ,
[2020-04-03 15:31:40.315] boot - 7  INFO [main] --- Application: The following profiles are active: docker,
[2020-04-03 15:31:45.025] boot - 7  INFO [main] --- RuleEngine: Starting Drools with drl files from:  /edgex/edgex-support-rulesengine/rules,
[2020-04-03 15:31:45.027] boot - 7  INFO [main] --- RuleEngine: Uploading Drool rules...,
[2020-04-03 15:31:45.080] boot - 7  INFO [main] --- RuleEngine: ... README,
[2020-04-03 15:31:45.175] boot - 7  WARN [main] --- MavenSettings: Environment variable M2_HOME is not set,
[2020-04-03 15:31:48.847] boot - 7  WARN [main] --- AbstractKieModule: No files found for KieBase defaultKieBase,
[2020-04-03 15:31:48.985] boot - 7  INFO [main] --- KieRepositoryImpl: KieModule was added: MemoryKieModule[releaseId=org.default:artifact:1.0.0-SNAPSHOT],
[2020-04-03 15:31:49.539] boot - 7  INFO [main] --- ExportClientImpl: Direct receiver of messages from core.  No export client registration,
[2020-04-03 15:31:51.090] boot - 7  WARN [main] --- URLConfigurationSource: No URLs will be polled as dynamic configuration sources.,
[2020-04-03 15:31:51.090] boot - 7  INFO [main] --- URLConfigurationSource: To enable URLs as dynamic configuration sources, define System property archaius.configurationSource.additionalUrls or make config.properties available on classpath.,
[2020-04-03 15:31:51.106] boot - 7  WARN [main] --- URLConfigurationSource: No URLs will be polled as dynamic configuration sources.,
[2020-04-03 15:31:51.107] boot - 7  INFO [main] --- URLConfigurationSource: To enable URLs as dynamic configuration sources, define System property archaius.configurationSource.additionalUrls or make config.properties available on classpath.,
[2020-04-03 15:31:51.541] boot - 7  INFO [pool-1-thread-1] --- HeartBeat: Support Rules Engine data heart beat,
[2020-04-03 15:31:51.681] boot - 7  INFO [main] --- Application: Started Application in 14.608 seconds (JVM running for 16.591),
This is the Support Rules Engine Microservice.,
[2020-04-03 15:31:51.852] boot - 7  INFO [main] --- ZeroMQEventSubscriber: Watching for new exported Event messages...,
[2020-04-03 15:31:56.121] boot - 7  INFO [main] --- ZeroMQEventSubscriber: JSON event received,
[2020-04-03 15:31:56.408] boot - 7  INFO [main] --- ZeroMQEventSubscriber: Event sent to rules engine for device id:  Random-UnsignedInteger-Device,
[2020-04-03 15:31:56.411] boot - 7  INFO [main] --- ZeroMQEventSubscriber: JSON event received,
[2020-04-03 15:31:56.416] boot - 7  INFO [main] --- ZeroMQEventSubscriber: Event sent to rules engine for device id:  Random-UnsignedInteger-Device,
[2020-04-03 15:31:56.421] boot - 7  INFO [main] --- ZeroMQEventSubscriber: JSON event received,
[2020-04-03 15:31:56.433] boot - 7  INFO [main] --- ZeroMQEventSubscriber: Event sent to rules engine for device id:  Random-UnsignedInteger-Device,
[2020-04-03 15:31:56.445] boot - 7  INFO [main] --- ZeroMQEventSubscriber: JSON event received,
[2020-04-03 15:31:56.452] boot - 7  INFO [main] --- ZeroMQEventSubscriber: Event sent to rules engine for device id:  Random-UnsignedInteger-Device,
[2020-04-03 15:31:56.457] boot - 7  INFO [main] --- ZeroMQEventSubscriber: JSON event received,
[2020-04-03 15:31:56.464] boot - 7  INFO [main] --- ZeroMQEventSubscriber: Event sent to rules engine for device id:  Random-Boolean-Device,
[2020-04-03 15:32:06.378] boot - 7  INFO [main] --- ZeroMQEventSubscriber: JSON event received,
[2020-04-03 15:32:06.386] boot - 7  INFO [main] --- ZeroMQEventSubscriber: Event sent to rules engine for device id:  Random-Float-Device,
[2020-04-03 15:32:06.444] boot - 7  INFO [main] --- ZeroMQEventSubscriber: JSON event received,
[2020-04-03 15:32:06.455] boot - 7  INFO [main] --- ZeroMQEventSubscriber: Event sent to rules engine for device id:  Random-Float-Device,
[2020-04-03 15:32:06.553] boot - 7  INFO [main] --- ZeroMQEventSubscriber: JSON event received,
[2020-04-03 15:32:06.563] boot - 7  INFO [main] --- ZeroMQEventSubscriber: Event sent to rules engine for device id:  Random-Integer-Device,
[2020-04-03 15:32:06.628] boot - 7  INFO [main] --- ZeroMQEventSubscriber: JSON event received,
[2020-04-03 15:32:06.644] boot - 7  INFO [main] --- ZeroMQEventSubscriber: Event sent to rules engine for device id:  Random-Integer-Device,
```