### PR TITLE
fix: Set logging URL to what is needed if remote logging is re-enabled.

### DIFF
--- a/docker-files/application.properties
+++ b/docker-files/application.properties
@@ -89,4 +89,4 @@ meta.db.provisionwatcher.url=http://edgex-core-metadata:48081/api/v1/provisionwa
 #-----------------Remote Logging Config------------------------------------------
 logging.remote.enable=false
 #logging.remote.url=http://localhost:48061/api/v1/logs
-#logging.remote.url=http://edgex-support-logging:48061/api/v1/logs
+logging.remote.url=http://edgex-support-logging:48061/api/v1/logs

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -87,5 +87,5 @@ meta.db.provisionwatcher.url=http://localhost:48081/api/v1/provisionwatcher
 #meta.db.provisionwatcher.url=http://edgex-core-metadata:48081/api/v1/provisionwatcher
 #-----------------Remote Logging Config------------------------------------------
 logging.remote.enable=false
-#logging.remote.url=http://localhost:48061/api/v1/logs
+logging.remote.url=http://localhost:48061/api/v1/logs
 #logging.remote.url=http://edgex-support-logging:48061/api/v1/logs


### PR DESCRIPTION
closes #74